### PR TITLE
handle prerelease specs too

### DIFF
--- a/lib/bundler_api.rb
+++ b/lib/bundler_api.rb
@@ -45,4 +45,8 @@ class BundlerApi < Sinatra::Base
   get "/specs.4.8.gz" do
     redirect "#{RUBYGEMS_URL}/specs.4.8.gz"
   end
+
+  get "/prerelease_specs.4.8.gz" do
+    redirect "#{RUBYGEMS_URL}/prerelease_specs.4.8.gz"
+  end
 end


### PR DESCRIPTION
if the API request fails for some reason, the fallback requests will include 
prerelease_specs.4.8.gz if the lock contains pre gems. this handles those.
