### PR TITLE
Add optional prefix to librato metrics

### DIFF
--- a/lib/bundler_api/metriks.rb
+++ b/lib/bundler_api/metriks.rb
@@ -17,11 +17,5 @@ if user && token
   opts[:prefix] = prefix if prefix && !prefix.empty?
 
   Metriks::Reporter::LibratoMetrics.new(user, token, opts).start
-else
-  require 'metriks/reporter/logger'
-  Metriks::Reporter::Logger.new(
-    logger: Logger.new("/dev/null"),
-    interval: 10
-  ).start
 end
 


### PR DESCRIPTION
Setting the `LIBRATO_METRICS_PREFIX` environment variable will pass it along to `Metriks::Reporter::LibratoMetrics`. Used when standing up multiple bundler-api apps to aggregate all metrics into the same Librato account but keeping each app separate.
