### PR TITLE
Add MAX_THREADS env var to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ RACK_ENV=development
 DATABASE_URL=postgres:///bundler-api
 FOLLOWER_DATABASE_URL=postgres:///bundler-api
 TEST_DATABASE_URL=postgres:///bundler-api-test
+MAX_THREADS=1
 ```
 
 Databases


### PR DESCRIPTION
`config/unicorn.rb` expects this to be set, otherwise starting unicorn crash with an error
