### PR TITLE
Load the environment variables from .env, if it exists, in script/setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ bundler-api
 Environment
 -----------
 
-The follow environment variables are needed to run bundler-api.
+The follow environment variables are needed to run bundler-api. You can 
+store these in the .gitignored ````.env```` file to have them automatically 
+loaded by Foreman and ````script/setup````.
 
-```
-RACK_ENV=development
-DATABASE_URL=postgres:///bundler-api
-FOLLOWER_DATABASE_URL=postgres:///bundler-api
-TEST_DATABASE_URL=postgres:///bundler-api-test
-```
+    RACK_ENV=development
+    DATABASE_URL=postgres:///bundler-api
+    FOLLOWER_DATABASE_URL=postgres:///bundler-api
+    TEST_DATABASE_URL=postgres:///bundler-api-test
+
 
 Databases
 ---------

--- a/script/setup
+++ b/script/setup
@@ -7,6 +7,10 @@ else
   exec 3>/dev/null
 fi
 
+if [ -e ".env" ]; then
+  while read line; do export $line; done < ".env"
+fi
+
 # DATABASE_URL env var is required to setup the database
 if [ -z "$DATABASE_URL" ]; then
   echo "DATABASE_URL environment variable required"


### PR DESCRIPTION
Very basic addition to load the local .env file into script/setup to make bootstrapping the application easier.
