### PR TITLE
Manage the environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
+# Default configuration. Override any of these settings by creating a
+# .env.local file.
+
 RACK_ENV=development
 DATABASE_URL=postgres:///bundler-api
 FOLLOWER_DATABASE_URL=postgres:///bundler-api

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ capybara-*.html
 pickle-email-*.html
 rerun.txt
 pickle-email-*.html
-.env
+.env.local
 tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 before_script:
   - psql -c 'create database "bundler-api";' -U postgres
-  - cp .env.example .env && export $(cat .env) && ./script/setup -v
+  - ./script/setup --verbose
 rvm: 1.9.3
 bundler_args: --binstubs
-script: export $(cat .env) && rspec
+script: rspec
 notifications:
   irc:
     on_success: change

--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,5 @@ group :test do
   gem 'rspec-core'
   gem 'rspec-expectations'
 end
+
+gem 'dotenv', require: false, groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
     atomic (1.1.13)
     avl_tree (1.1.3)
     diff-lcs (1.2.4)
+    dotenv (0.9.0)
     faraday (0.8.8)
       multipart-post (~> 1.2.0)
     hitimes (1.2.1)
@@ -53,6 +54,7 @@ PLATFORMS
 
 DEPENDENCIES
   artifice
+  dotenv
   honeybadger
   librato-metrics
   lock-smith

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec puma --include lib --port $PORT --environment $RACK_ENV --threads $MIN_THREADS:$MAX_THREADS
+web: script/web
 update: bundle exec rake continual_update[5,500]

--- a/README.md
+++ b/README.md
@@ -3,19 +3,17 @@
 
 # bundler-api
 
+## Getting Started
+
+Run `script/build` to create and migrate the database specified in the
+`$DATABASE_URL` environment variable.
+
 ## Environment
 
-The follow environment variables are needed to run bundler-api. You can store
-these in the .gitignored `.env` file to have them automatically loaded by
-Foreman and `script/setup`.
+The default environment is stored in `.env`. Override any of the settings
+found there by creating a `.env.local` file.
 
-    RACK_ENV=development
-    DATABASE_URL=postgres:///bundler-api
-    FOLLOWER_DATABASE_URL=postgres:///bundler-api
-    TEST_DATABASE_URL=postgres:///bundler-api-test
-
-
-## Databases
+## Production Databases
 
   - `COBALT`: Master database.
   - `PURPLE`: Following `COBALT`. Read by public API to resolve dependencies.

--- a/lib/bundler_api/env.rb
+++ b/lib/bundler_api/env.rb
@@ -1,0 +1,17 @@
+module BundlerApi
+  class Env
+    def self.load
+      return unless local_env?
+      require 'dotenv'
+      Dotenv.load '.env.local', '.env'
+    end
+
+    def self.local_env?
+      ENV['RACK_ENV'].nil? or
+        ENV['RACK_ENV'] == 'development' or
+        ENV['RACK_ENV'] == 'test'
+    end
+  end
+end
+
+BundlerApi::Env.load

--- a/puma.rb
+++ b/puma.rb
@@ -1,0 +1,8 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'bundler/setup'
+require 'bundler_api/env'
+
+threads ENV.fetch('MIN_THREADS', 0), ENV.fetch('MAX_THREADS', 1)
+port ENV['PORT'] if ENV['PORT']

--- a/script/setup
+++ b/script/setup
@@ -1,40 +1,64 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env ruby
+# Create and migrate the database specified in the $DATABASE_URL environment
+# variable.
+#
+# Usage: script/rebuild [--verbose] [--rebuild]
+#
+# Options:
+#   --rebuild: drop the database before creating it
+#   --verbose: print errors and warnings from postgres
 
-if [ "$1" = "-v" ]; then
-  exec 3>&1
-else
-  exec 3>/dev/null
-fi
+$stdout.sync = true
 
-if [ -e ".env" ]; then
-  while read line; do export $line; done < ".env"
-fi
+lib = File.expand_path(File.join('..', '..', 'lib'), __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-# DATABASE_URL env var is required to setup the database
-if [ -z "$DATABASE_URL" ]; then
-  echo "DATABASE_URL environment variable required"
-  exit 1
-fi
+require 'bundler/setup'
+require 'bundler_api/env'
+require 'open3'
 
-dbname=$(basename "$DATABASE_URL")
+def rebuild?
+  @rebuild ||= ARGV.delete('--rebuild')
+end
 
-# Wipe and load the database if DROPDB env var is set.
-if [ -n "$DROPDB" ]; then
-  echo "Dropping the database"
-  { psql -tAl | grep -E "^$dbname\|" >/dev/null && \
-      dropdb $dbname
-  } >&3 2>&1
-fi
+def verbose?
+  @verbose ||= (ARGV.delete('-v') || ARGV.delete('--verbose'))
+end
 
-echo "Creating the database unless exists"
-{ psql -tAl | grep -E "^$dbname\|" >/dev/null || \
-  createdb --no-password $dbname
-} >&3 2>&1
+def print_output(output)
+  return if !verbose? or output.empty?
+  output.lines.each do |line|
+    puts "  #{line}"
+  end
+  puts
+end
 
-echo "Migrating the database"
-sequel -m db/migrations $DATABASE_URL >&3 2>&1
+def database_url
+  ENV['DATABASE_URL']
+end
 
-echo "Done!
-Run \`rake update\` and \`rake fix_deps\` to populate the database with \
+def database_name
+  File.basename(database_url)
+end
+
+abort 'DATABASE_URL environment variable required' unless database_url
+
+if rebuild?
+  puts 'Dropping database'
+  output, _ = Open3.capture2e(*%W(dropdb --if-exists #{database_name}))
+  print_output output
+end
+
+puts 'Creating database'
+output, _ = Open3.capture2e(*%W{createdb --no-password #{database_name}})
+print_output output
+
+puts 'Migrating database'
+output, _ = Open3.capture2e(*%W{sequel --migrate-directory db/migrations
+                                       #{database_url}})
+print_output output
+
+puts "
+Done! \
+Run `rake update` and `rake fix_deps` to populate the database with \
 all gems from rubygems.org."

--- a/script/web
+++ b/script/web
@@ -1,0 +1,2 @@
+#!/usr/bin/env ruby
+exec 'puma', '--config', 'puma.rb'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
 require 'bundler/setup'
+
+ENV['RACK_ENV'] = 'test'
+require 'bundler_api/env'
+
 require 'rspec/core'
 require 'support/database'
 require 'support/latch'
-
-ENV['RACK_ENV'] = 'test'
 
 RSpec.configure do |config|
   config.filter_run :focused => true


### PR DESCRIPTION
Use dotenv to manage ENV in development and test environments instead of requiring `foreman run`. This means the app should be bootable without needing to create a `.env` file. One caveat is `.env` was previously ignored. Applying this commit may error or silently destroy the local copy. Moving .env to .env.local before applying will retain the same behavior.

@indirect and @hone, any objections?
