### PR TITLE
Limit gem dependency requests to 100 gems.

### DIFF
--- a/lib/bundler_api/web.rb
+++ b/lib/bundler_api/web.rb
@@ -99,7 +99,7 @@ class BundlerApi::Web < Sinatra::Base
   end
 
   get "/api/v1/dependencies" do
-    halt 422, "Too many gems" if gems.length > API_REQUEST_LIMIT
+    halt 422, "Too many gems (use --full-index instead)" if gems.length > API_REQUEST_LIMIT
 
     content_type 'application/octet-stream'
     deps = get_deps
@@ -107,7 +107,10 @@ class BundlerApi::Web < Sinatra::Base
   end
 
   get "/api/v1/dependencies.json" do
-    halt 422, {:error => "Too many gems"}.to_json if gems.length > API_REQUEST_LIMIT
+    halt 422, {
+      "error" => "Too many gems (use --full-index instead)",
+      "code"  => 422
+    }.to_json if gems.length > API_REQUEST_LIMIT
 
     content_type 'application/json;charset=UTF-8'
     get_deps.to_json

--- a/lib/bundler_api/web.rb
+++ b/lib/bundler_api/web.rb
@@ -12,10 +12,10 @@ require 'bundler_api/gem_helper'
 require 'bundler_api/update/job'
 require 'bundler_api/update/yank_job'
 
-
 class BundlerApi::Web < Sinatra::Base
-  RUBYGEMS_URL = ENV['RUBYGEMS_URL'] || "https://www.rubygems.org"
+  API_REQUEST_LIMIT    = 100
   PG_STATEMENT_TIMEOUT = 1000
+  RUBYGEMS_URL         = ENV['RUBYGEMS_URL'] || "https://www.rubygems.org"
 
   unless ENV['RACK_ENV'] == 'test'
     use Metriks::Middleware
@@ -99,12 +99,16 @@ class BundlerApi::Web < Sinatra::Base
   end
 
   get "/api/v1/dependencies" do
+    halt 422, "Too many gems" if gems.length > API_REQUEST_LIMIT
+
     content_type 'application/octet-stream'
     deps = get_deps
     Marshal.dump(deps)
   end
 
   get "/api/v1/dependencies.json" do
+    halt 422, {:error => "Too many gems"}.to_json if gems.length > API_REQUEST_LIMIT
+
     content_type 'application/json;charset=UTF-8'
     get_deps.to_json
   end

--- a/spec/web_spec.rb
+++ b/spec/web_spec.rb
@@ -72,6 +72,17 @@ describe BundlerApi::Web do
         expect(Marshal.load(last_response.body)).to eq(result)
       end
     end
+
+    context "there are too many gems" do
+      let(:gems) { 101.times.map { |i| "gem-#{ i }" }.join(',') }
+
+      it "returns a 422" do
+        get "#{request}?gems=#{ gems }"
+
+        expect(last_response).not_to be_ok
+        expect(last_response.body).to eq("Too many gems")
+      end
+    end
   end
 
 
@@ -100,6 +111,18 @@ describe BundlerApi::Web do
 
         expect(last_response).to be_ok
         expect(JSON.parse(last_response.body)).to eq(result)
+      end
+    end
+
+    context "there are too many gems" do
+      let(:gems) { 101.times.map { |i| "gem-#{ i }" }.join(',') }
+
+      it "returns a 422" do
+        error = {:error => "Too many gems"}.to_json
+        get "#{request}?gems=#{ gems }"
+
+        expect(last_response).not_to be_ok
+        expect(last_response.body).to eq(error)
       end
     end
   end

--- a/spec/web_spec.rb
+++ b/spec/web_spec.rb
@@ -80,7 +80,7 @@ describe BundlerApi::Web do
         get "#{request}?gems=#{ gems }"
 
         expect(last_response).not_to be_ok
-        expect(last_response.body).to eq("Too many gems")
+        expect(last_response.body).to eq("Too many gems (use --full-index instead)")
       end
     end
   end
@@ -118,7 +118,11 @@ describe BundlerApi::Web do
       let(:gems) { 101.times.map { |i| "gem-#{ i }" }.join(',') }
 
       it "returns a 422" do
-        error = {:error => "Too many gems"}.to_json
+        error = {
+          "error" => "Too many gems (use --full-index instead)",
+          "code"  => 422
+        }.to_json
+
         get "#{request}?gems=#{ gems }"
 
         expect(last_response).not_to be_ok


### PR DESCRIPTION
This will severely decrease the timeout errors we've been having. 

From what I could tell, it seems that someone is using a hacked version of Bundler (by removing the gem limit), which in turn times out our API and breaks it for a small period of time for everyone else.