### PR TITLE
Dependencies api v2

### DIFF
--- a/lib/bundler_api/cdn.rb
+++ b/lib/bundler_api/cdn.rb
@@ -21,6 +21,12 @@ class BundlerApi::Cdn
     purge_gem_by_name gem.full_name, client
   end
 
+  def self.purge_gem_dependency(name, client = self.client)
+    return unless client
+    client.purge_key "/api/v2/dependencies/#{name}"
+    client.purge_key "/api/v2/dependencies/#{name}.json"
+  end
+
   def self.client
     return unless service_id && base_url
     Client.new(service_id, base_url, api_key)


### PR DESCRIPTION
[replaces #59]

### Problem
`api/v1/dependencies?gems=huge_list` can take a while as this needs to return all dependencies for the list of gems given. The sql query is the bigger bottom neck https://github.com/bundler/bundler-api/blob/master/lib/bundler_api/dep_calc.rb#L8-L21, besides that, to Marshal a big list is not fast too.

### Solution
`api/v2/dependencies` will only solve dependencies for one gem, so we can
better CDN cache that request.

### Work necessary on the bundler client
As the client will request a lot to this api now, we need to make sure the client uses http-pipelining so we send all requests using the same connection and avoid the overhead of opening a lot of connections.

review @andremedeiros @hone @indirect @dwradcliffe