### PR TITLE
Print backtrace on librato error.

### DIFF
--- a/lib/bundler_api/metriks.rb
+++ b/lib/bundler_api/metriks.rb
@@ -16,7 +16,11 @@ if user && token
     Socket.gethostname
   end
 
-  on_error = ->(e) do STDOUT.puts("LibratoMetrics: #{ e.message }") end
+  on_error = ->(e) do
+    STDOUT.puts("LibratoMetrics: #{ e.message }")
+    STDOUT.puts(e.backtrace)
+  end
+
   opts     = { on_error: on_error, source: app_name }
   opts[:prefix] = prefix if prefix && !prefix.empty?
 


### PR DESCRIPTION
As far as we can tell, metriks-librato_metrics is failing to send data,
and it never cleans the data.

We are getting errors like:
LibratoMetrics: Broken pipe

on the logs, but without any stacktrace. With a trace we can know better
why the pipe is broken.