### PR TITLE
Fix rescue syntax

### DIFF
--- a/lib/bundler_api/agent_reporting.rb
+++ b/lib/bundler_api/agent_reporting.rb
@@ -46,7 +46,7 @@ private
 
     BundlerApi.redis.setex(id, 120, true)
     false
-  rescue ex
+  rescue => ex
     # Sometimes we get these, and there's no point throwing out a perfectly
     # good metric. We still, however, want to report it in Appsignal so that
     # we know what's up.


### PR DESCRIPTION
Maybe I am missing something, but as far as I can tell `rescue ex` wont work. see a small test https://gist.github.com/arthurnn/ff127c64591953768144 .

cheers.
review @andremedeiros 