### PR TITLE
Add default ttl, 15 min to gem cache

### DIFF
--- a/lib/bundler_api/cache.rb
+++ b/lib/bundler_api/cache.rb
@@ -69,7 +69,8 @@ module BundlerApi
                              password: ENV["MEMCACHIER_PASSWORD"],
                              failover: true,
                              socket_timeout: 1.5,
-                             socket_failure_delay: 0.2
+                             socket_failure_delay: 0.2,
+                             expires_in: 15 * 60
                             })
         else
           Dalli::Client.new


### PR DESCRIPTION
Not sure how, but we are getting some gem cache out-of-sync.
Probably some race condition, or a something else.
If we add a ttl, it will fix the issue, even if that doesnt make me happy.

We can play if the TTL, after we deploy this, we can watch the number of cache miss,
and lower or increase this number
