### PR TITLE
Keep track of which CI run a command if any

### DIFF
--- a/lib/bundler_api/agent_reporting.rb
+++ b/lib/bundler_api/agent_reporting.rb
@@ -9,6 +9,7 @@ class BundlerApi::AgentReporting
     \((?<arch>.*)\)\s
     command/(?<command>\w+)\s
     (?:options/(?<options>\S+)\s)?
+    (?:ci/(?<ci>\S+)\s)?
     (?<id>.*)
   }x
 
@@ -31,11 +32,15 @@ private
       "versions.rubygems.#{ ua_match['gem_version'] }",
       "versions.ruby.#{ ua_match['ruby_version'] }",
       "archs.#{ ua_match['arch'] }",
-      "commands.#{ ua_match['command'] }"
+      "commands.#{ ua_match['command'] }",
     ]
 
     if ua_match['options']
       keys += ua_match['options'].split(",").map { |k| "options.#{ k }" }
+    end
+
+    if ua_match['ci']
+      keys += ua_match['ci'].split(",").map { |k| "cis.#{ k }" }
     end
 
     keys.each { |metric| Metriks.meter(metric).mark }

--- a/spec/agent_reporting_spec.rb
+++ b/spec/agent_reporting_spec.rb
@@ -20,6 +20,7 @@ describe BundlerApi::AgentReporting do
       '(x86_64-apple-darwin13.2.0)',
       'command/update',
       'options/jobs,without,build.mysql',
+      'ci/jenkins,ci',
       '9d16bd9809d392ca' ].join(' ')
   end
 
@@ -40,6 +41,8 @@ describe BundlerApi::AgentReporting do
         expect( metriks ).to be_incremented_for('options.jobs')
         expect( metriks ).to be_incremented_for('options.without')
         expect( metriks ).to be_incremented_for('options.build.mysql')
+        expect( metriks ).to be_incremented_for('cis.jenkins')
+        expect( metriks ).to be_incremented_for('cis.ci')
       end
     end
 
@@ -58,6 +61,7 @@ describe BundlerApi::AgentReporting do
         'ruby/2.1.2',
         '(x86_64-apple-darwin13.2.0)',
         'command/update',
+        'ci/semaphore',
         '9d16bd9809d392ca' ].join(' ')
     end
 
@@ -68,6 +72,7 @@ describe BundlerApi::AgentReporting do
         expect( metriks ).to be_incremented_for('versions.ruby.2.1.2')
         expect( metriks ).to be_incremented_for('commands.update')
         expect( metriks ).to be_incremented_for('archs.x86_64-apple-darwin13.2.0')
+        expect( metriks ).to be_incremented_for('cis.semaphore')
       end
     end
 


### PR DESCRIPTION
This patch is a complement from the new information sent by bundler on the user agent. It add a new metrik that keep track of how often different CIs run bundler commands.