### PR TITLE
Move response bodies to compact_index gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'rake'
 gem 'sequel'
 gem 'sequel_pg'
 gem 'sinatra'
-gem 'compact_index', github: 'bundler/compact_index'
+gem 'compact_index', "~> 0.2"
 
 group :development do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: git://github.com/bundler/compact_index.git
-  revision: 52b29ef3d459093edb5fb69eb109c8d346588955
-  specs:
-    compact_index (0.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -18,6 +12,9 @@ GEM
       slop (~> 3.6)
     coderay (1.1.0)
     columnize (0.8.9)
+    compact_index (0.2.0)
+      pg
+      sequel
     debugger-linecache (1.2.0)
     diff-lcs (1.2.4)
     dotenv (0.9.0)
@@ -77,7 +74,7 @@ PLATFORMS
 
 DEPENDENCIES
   artifice
-  compact_index!
+  compact_index (~> 0.2)
   dotenv
   honeybadger
   librato-metrics


### PR DESCRIPTION
The response body is also shared by rubygems.org and bundler-api. So it
is natural to move this code to compact-index gem.

This patch does not remove the spec format response. I think it is
healty to keep some basic test on the response format as well, so we can
do more complete tests on the compact-index itself.

Thoughts?