### PR TITLE
Fixes so script/web works

### DIFF
--- a/lib/bundler_api/metriks.rb
+++ b/lib/bundler_api/metriks.rb
@@ -3,9 +3,9 @@ require 'metriks/middleware'
 require 'metriks-librato_metrics'
 
 module BundlerApi
-  module Metriks
+  class Metriks
     def self.start(worker_index = nil)
-      new(ENV['LIBRATO_METRICS_USER'], ENV['LIBRATO_METRICS_TOKEN'], worker_index).start
+      new(ENV['LIBRATO_METRICS_USER'], ENV['LIBRATO_METRICS_TOKEN'], worker_index)
     end
 
     def initialize(user, token, worker_index = nil)


### PR DESCRIPTION
After a fresh checkout, I ran script/setup which didn't give any errors, so I ran script/web to start the server. It gave 2 errors, which this PR fixes. After I made this patch, it all started fine and seems to work ok.

The errors I got:

```sh
~/ws/bundler-api/lib/bundler_api/metriks.rb:8:in `start': undefined method `new' for BundlerApi::Metriks:Module (NoMethodError)
	from puma.rb:6:in `_load_from'
	from ~/.rvm/gems/ruby-2.2.2/gems/puma-2.11.3/lib/puma/dsl.rb:20:in `instance_eval'
```

```sh
~/ws/bundler-api/lib/bundler_api/metriks.rb:8:in `start': undefined method `start' for #<BundlerApi::Metriks:0x00000002459fc8> (NoMethodError)
	from puma.rb:6:in `_load_from'
	from ~/.rvm/gems/ruby-2.2.2/gems/puma-2.11.3/lib/puma/dsl.rb:20:in `instance_eval'
```

I did the most straightforward fix for now... I made the Metriks module a class so new will work, and I dropped the call to start in Metriks::start, as Metriks#initialize seems to already be making the intended start call.