### PR TITLE
Check dependencies before setting up

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -28,6 +28,19 @@ def verbose?
   @verbose ||= (ARGV.delete('-v') || ARGV.delete('--verbose'))
 end
 
+def run_command(*args)
+  output, status = Open3.capture2e(*args)
+  print_output output
+
+  unless status.success?
+    if verbose?
+      abort
+    else
+      abort 'Error! Please rerun with --verbose for more details'
+    end
+  end
+end
+
 def print_output(output)
   return if !verbose? || output.empty?
   output.lines.each do |line|
@@ -55,6 +68,16 @@ end
 
 def postgres_installed?
   !`which psql`.strip.empty?
+end
+
+def database_exists?
+  Sequel.connect(database_url) do |db|
+    db.test_connection
+  end
+
+  true
+rescue
+  false
 end
 
 def postgres_ready?
@@ -102,24 +125,23 @@ end
 
 abort 'DATABASE_URL environment variable required' unless database_url
 
-unless postgres_installed?
-  abort 'Please install postgresql first'
-end
-
 if rebuild?
   puts 'Dropping database'
-  output, _ = Open3.capture2e(*%W(dropdb --if-exists #{database_name}))
-  print_output output
+  run_command(*%W(dropdb --if-exists #{database_name}))
 end
 
-puts 'Creating database'
-output, _ = Open3.capture2e(*%W{createdb --no-password #{database_name}})
-print_output output
+unless database_exists?
+  unless postgres_installed?
+    abort 'Please install postgresql or specify a connection to an existing database in .env.local'
+  end
+
+  puts 'Creating database'
+  run_command(*%W{createdb --no-password #{database_name}})
+end
 
 puts 'Migrating database'
-output, _ = Open3.capture2e(*%W{sequel --migrate-directory db/migrations
-                                       #{database_url}})
-print_output output
+run_command(*%W{sequel --migrate-directory db/migrations
+                       #{database_url}})
 
 verify_dependencies
 

--- a/script/setup
+++ b/script/setup
@@ -17,6 +17,7 @@ require 'bundler/setup'
 require 'bundler_api/env'
 require 'bundler_api/cache'
 require 'bundler_api/redis'
+require 'sequel'
 require 'open3'
 
 def rebuild?
@@ -35,6 +36,15 @@ def print_output(output)
   puts
 end
 
+def print_error(title, error)
+  return unless verbose?
+  $stderr.puts "#{title}: #{error}"
+
+  error.backtrace.each do |line|
+    $stderr.puts "  #{line}"
+  end
+end
+
 def database_url
   ENV['DATABASE_URL']
 end
@@ -47,35 +57,54 @@ def postgres_installed?
   !`which psql`.strip.empty?
 end
 
+def postgres_ready?
+  Sequel.connect(database_url) do |db|
+    db[:versions].first
+  end
+
+  true
+rescue => e
+  print_error "Postgres error", e
+  false
+end
+
 def redis_ready?
   BundlerApi.redis.ping
   true
-rescue
+rescue => e
+  print_error "Redis error", e
   false
 end
 
 def memcached_ready?
   BundlerApi::CacheInvalidator.new.memcached_client.alive!
   true
-rescue
+rescue => e
+  print_error "Memcached error", e
   false
 end
 
 def verify_dependencies
   puts 'Checking dependencies'
   unmet = []
-  unmet << '  * postgres' unless postgres_installed?
-  unmet << '  * redis' unless redis_ready?
-  unmet << '  * memcached' unless memcached_ready?
+  unmet << 'postgres' unless postgres_ready?
+  unmet << 'redis' unless redis_ready?
+  unmet << 'memcached' unless memcached_ready?
 
   unless unmet.empty?
-    abort "You have dependencies that are unmet or are not available:\n#{unmet.join("\n")}"
+    $stderr.puts 'You have dependencies that are unmet or are not available:'
+
+    unmet.each do |dependency|
+      $stderr.puts "  * #{dependency}"
+    end
   end
 end
 
 abort 'DATABASE_URL environment variable required' unless database_url
 
-verify_dependencies
+unless postgres_installed?
+  abort 'Please install postgresql first'
+end
 
 if rebuild?
   puts 'Dropping database'
@@ -91,6 +120,8 @@ puts 'Migrating database'
 output, _ = Open3.capture2e(*%W{sequel --migrate-directory db/migrations
                                        #{database_url}})
 print_output output
+
+verify_dependencies
 
 puts "
 Done! \

--- a/script/setup
+++ b/script/setup
@@ -30,19 +30,12 @@ end
 
 def run_command(*args)
   output, status = Open3.capture2e(*args)
-  print_output output
-
-  unless status.success?
-    if verbose?
-      abort
-    else
-      abort 'Error! Please rerun with --verbose for more details'
-    end
-  end
+  print_output(output, !status.success? || verbose?)
+  abort unless status.success?
 end
 
-def print_output(output)
-  return if !verbose? || output.empty?
+def print_output(output, verbose)
+  return if !verbose || output.empty?
   output.lines.each do |line|
     puts "  #{line}"
   end

--- a/script/setup
+++ b/script/setup
@@ -2,7 +2,7 @@
 # Create and migrate the database specified in the $DATABASE_URL environment
 # variable.
 #
-# Usage: script/rebuild [--verbose] [--rebuild]
+# Usage: script/setup [--verbose] [--rebuild]
 #
 # Options:
 #   --rebuild: drop the database before creating it
@@ -15,6 +15,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'bundler/setup'
 require 'bundler_api/env'
+require 'bundler_api/cache'
+require 'bundler_api/redis'
 require 'open3'
 
 def rebuild?
@@ -41,7 +43,39 @@ def database_name
   File.basename(database_url)
 end
 
+def postgres_installed?
+  !`which psql`.strip.empty?
+end
+
+def redis_ready?
+  BundlerApi.redis.ping
+  true
+rescue
+  false
+end
+
+def memcached_ready?
+  BundlerApi::CacheInvalidator.new.memcached_client.alive!
+  true
+rescue
+  false
+end
+
+def verify_dependencies
+  puts 'Checking dependencies'
+  unmet = []
+  unmet << '  * postgres' unless postgres_installed?
+  unmet << '  * redis' unless redis_ready?
+  unmet << '  * memcached' unless memcached_ready?
+
+  unless unmet.empty?
+    abort "You have dependencies that are unmet or are not available:\n#{unmet.join("\n")}"
+  end
+end
+
 abort 'DATABASE_URL environment variable required' unless database_url
+
+verify_dependencies
 
 if rebuild?
   puts 'Dropping database'


### PR DESCRIPTION
When I ran script/setup on a machine that didn't have postgresql (but it did have postgres dev libs apparently, as the pg gem installed without problem), I get the following error:

```sh
$ script/setup
Creating database
~/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/open3.rb:193:in `spawn': No such file or directory - createdb (Errno::ENOENT)
	from ~/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/open3.rb:193:in `popen_run'
	from ~/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/open3.rb:188:in `popen2e'
	from ~/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/open3.rb:335:in `capture2e'
	from script/setup:53:in `<main>'
```

When I ran script/setup on my other machine that had postgresql set up, but not memcached, the server set up fine, ran fine, but the specs failed until I installed memcached.

It seems like some dependency checks might help out someone doing a fresh setup, so that's what this PR is about.

This might be overreaching the scope of script/setup, but it seems useful to someone setting up a server, especially for the first time.

Oh, and script/rebuild usage line seemed like a typo :-)