### PR TITLE
Extract redirect strategy

### DIFF
--- a/lib/bundler_api/strategy.rb
+++ b/lib/bundler_api/strategy.rb
@@ -1,0 +1,39 @@
+module BundlerApi
+  class RedirectionStrategy
+    def initialize(rubygems_url, server)
+      @rubygems_url = rubygems_url
+      @server = server
+    end
+
+    def get_marshal(id)
+      redirect "/quick/Marshal.4.8/#{id}"
+    end
+
+    def get_actual_gem(id)
+      redirect "/fetch/actual/gem/#{:id}"
+    end
+
+    def get_gem(id)
+      redirect "/gems/#{:id}"
+    end
+
+    def get_latest_specs
+      redirect "/latest_specs.4.8.gz"
+    end
+
+    def get_specs
+      redirect "/specs.4.8.gz"
+    end
+
+    def get_prerelease_specs
+      redirect "/prerelease_specs.4.8.gz"
+    end
+
+    private
+
+    def redirect(path)
+      @server.redirect "#{@rubygems_url}#{path}"
+    end
+
+  end
+end

--- a/lib/bundler_api/strategy.rb
+++ b/lib/bundler_api/strategy.rb
@@ -1,38 +1,31 @@
 module BundlerApi
   class RedirectionStrategy
-    def initialize(rubygems_url, server)
+    def initialize(rubygems_url)
       @rubygems_url = rubygems_url
-      @server = server
     end
 
-    def get_marshal(id)
-      redirect "/quick/Marshal.4.8/#{id}"
+    def get_marshal(id, app)
+      app.redirect "#{@rubygems_url}/quick/Marshal.4.8/#{id}"
     end
 
-    def get_actual_gem(id)
-      redirect "/fetch/actual/gem/#{:id}"
+    def get_actual_gem(id, app)
+      app.redirect "#{@rubygems_url}/fetch/actual/gem/#{:id}"
     end
 
-    def get_gem(id)
-      redirect "/gems/#{:id}"
+    def get_gem(id, app)
+      app.redirect "#{@rubygems_url}/gems/#{:id}"
     end
 
-    def get_latest_specs
-      redirect "/latest_specs.4.8.gz"
+    def get_latest_specs(app)
+      app.redirect "#{@rubygems_url}/latest_specs.4.8.gz"
     end
 
-    def get_specs
-      redirect "/specs.4.8.gz"
+    def get_specs(app)
+      app.redirect "#{@rubygems_url}/specs.4.8.gz"
     end
 
-    def get_prerelease_specs
-      redirect "/prerelease_specs.4.8.gz"
-    end
-
-    private
-
-    def redirect(path)
-      @server.redirect "#{@rubygems_url}#{path}"
+    def get_prerelease_specs(app)
+      app.redirect "#{@rubygems_url}/prerelease_specs.4.8.gz"
     end
 
   end

--- a/lib/bundler_api/strategy.rb
+++ b/lib/bundler_api/strategy.rb
@@ -4,27 +4,27 @@ module BundlerApi
       @rubygems_url = rubygems_url
     end
 
-    def get_marshal(id, app)
+    def serve_marshal(id, app)
       app.redirect "#{@rubygems_url}/quick/Marshal.4.8/#{id}"
     end
 
-    def get_actual_gem(id, app)
+    def serve_actual_gem(id, app)
       app.redirect "#{@rubygems_url}/fetch/actual/gem/#{:id}"
     end
 
-    def get_gem(id, app)
+    def serve_gem(id, app)
       app.redirect "#{@rubygems_url}/gems/#{:id}"
     end
 
-    def get_latest_specs(app)
+    def serve_latest_specs(app)
       app.redirect "#{@rubygems_url}/latest_specs.4.8.gz"
     end
 
-    def get_specs(app)
+    def serve_specs(app)
       app.redirect "#{@rubygems_url}/specs.4.8.gz"
     end
 
-    def get_prerelease_specs(app)
+    def serve_prerelease_specs(app)
       app.redirect "#{@rubygems_url}/prerelease_specs.4.8.gz"
     end
 

--- a/lib/bundler_api/web.rb
+++ b/lib/bundler_api/web.rb
@@ -11,6 +11,7 @@ require 'bundler_api/runtime_instrumentation'
 require 'bundler_api/gem_helper'
 require 'bundler_api/update/job'
 require 'bundler_api/update/yank_job'
+require 'bundler_api/strategy'
 
 class BundlerApi::Web < Sinatra::Base
   API_REQUEST_LIMIT    = 200
@@ -24,7 +25,7 @@ class BundlerApi::Web < Sinatra::Base
     use BundlerApi::AgentReporting
   end
 
-  def initialize(conn = nil, write_conn = nil)
+  def initialize(conn = nil, write_conn = nil, gem_strategy = nil)
     @rubygems_token = ENV['RUBYGEMS_TOKEN']
 
     statement_timeout = proc {|c| c.execute("SET statement_timeout = #{PG_STATEMENT_TIMEOUT}") }
@@ -42,6 +43,7 @@ class BundlerApi::Web < Sinatra::Base
     @cache = BundlerApi::CacheInvalidator.new
     @dalli_client = @cache.memcached_client
     super()
+    @gem_strategy = gem_strategy || BundlerApi::RedirectionStrategy.new(RUBYGEMS_URL)
   end
 
   set :root, File.join(File.dirname(__FILE__), '..', '..')
@@ -139,27 +141,27 @@ class BundlerApi::Web < Sinatra::Base
   end
 
   get "/quick/Marshal.4.8/:id" do
-    redirect "#{RUBYGEMS_URL}/quick/Marshal.4.8/#{params[:id]}"
+    @gem_strategy.get_marshal(params[:id], self)
   end
 
   get "/fetch/actual/gem/:id" do
-    redirect "#{RUBYGEMS_URL}/fetch/actual/gem/#{params[:id]}"
+    @gem_strategy.get_actual_gem(params[:id], self)
   end
 
   get "/gems/:id" do
-    redirect "#{RUBYGEMS_URL}/gems/#{params[:id]}"
+    @gem_strategy.get_gem(params[:id], self)
   end
 
   get "/latest_specs.4.8.gz" do
-    redirect "#{RUBYGEMS_URL}/latest_specs.4.8.gz"
+    @gem_strategy.get_latest_specs(self)
   end
 
   get "/specs.4.8.gz" do
-    redirect "#{RUBYGEMS_URL}/specs.4.8.gz"
+    @gem_strategy.get_specs(self)
   end
 
   get "/prerelease_specs.4.8.gz" do
-    redirect "#{RUBYGEMS_URL}/prerelease_specs.4.8.gz"
+    @gem_strategy.get_prerelease_specs(self)
   end
 
   private

--- a/lib/bundler_api/web.rb
+++ b/lib/bundler_api/web.rb
@@ -141,27 +141,27 @@ class BundlerApi::Web < Sinatra::Base
   end
 
   get "/quick/Marshal.4.8/:id" do
-    @gem_strategy.get_marshal(params[:id], self)
+    @gem_strategy.serve_marshal(params[:id], self)
   end
 
   get "/fetch/actual/gem/:id" do
-    @gem_strategy.get_actual_gem(params[:id], self)
+    @gem_strategy.serve_actual_gem(params[:id], self)
   end
 
   get "/gems/:id" do
-    @gem_strategy.get_gem(params[:id], self)
+    @gem_strategy.serve_gem(params[:id], self)
   end
 
   get "/latest_specs.4.8.gz" do
-    @gem_strategy.get_latest_specs(self)
+    @gem_strategy.serve_latest_specs(self)
   end
 
   get "/specs.4.8.gz" do
-    @gem_strategy.get_specs(self)
+    @gem_strategy.serve_specs(self)
   end
 
   get "/prerelease_specs.4.8.gz" do
-    @gem_strategy.get_prerelease_specs(self)
+    @gem_strategy.serve_prerelease_specs(self)
   end
 
   private


### PR DESCRIPTION
This is a RFC which opens the door for changing what do the server does when a gem (or any other URL) is requested, for now this is simply extracting the redirection strategy that is already embedded in the app into an object that does exactly that: redirect to rubygems.

The way to continue from here is creating a caching strategy object that will have a storage of some kind, (probably just a local storage on a folder). On request, this object will first search for the file in this local storage, if it finds it, it will just serve it with the caching file and http headers; else it will pull the file to make a local cache.

The way of caching a file is simply using some smart enough http object like Faraday, pull the file following redirects (as rubygems redirects to S3), and store both the file and headers returned by S3 into a folder with the same name as the gem file (gem name + version).

To set up this caching layer, we only need to inject this caching strategy object into the app on construction.

Possible next step after that: having a 2 step strategy, that can look for files in a different "private" folder, and then cache it from rubygems in case it is not found, this would bring support for "private gems".
This second layer would probably require some UI or bundler support to "push" a gem file to this local server.