### PR TITLE
Lazy load dependencies from rubygems.org

### DIFF
--- a/lib/bundler_api/dep_calc.rb
+++ b/lib/bundler_api/dep_calc.rb
@@ -5,10 +5,11 @@ class BundlerApi::DepCalc
 
   # TODO: These 2 methods may not really belong here
   # TODO: There are a lot more queries than are probably needed
-  # TODO: Should this stuff be wrapped in a transaction?
   def self.store_dependencies(connection, dependencies)
-    dependencies.each do |dep|
-      store_dependency(connection, dep)
+    connection.transaction do
+      dependencies.each do |dep|
+        store_dependency(connection, dep)
+      end
     end
   end
 

--- a/lib/bundler_api/dep_calc.rb
+++ b/lib/bundler_api/dep_calc.rb
@@ -3,51 +3,6 @@ require 'bundler_api'
 class BundlerApi::DepCalc
   DepKey = Struct.new(:name, :number, :platform)
 
-  # TODO: These 2 methods may not really belong here
-  # TODO: There are a lot more queries than are probably needed
-  def self.store_dependencies(connection, dependencies)
-    connection.transaction do
-      dependencies.each do |dep|
-        store_dependency(connection, dep)
-      end
-    end
-  end
-
-  def self.store_dependency(connection, dependency)
-    gem = connection[:rubygems][name: dependency[:name]]
-
-    if gem
-      gem_id = gem[:id]
-    else
-      gem_id = connection[:rubygems].insert(name: dependency[:name])
-    end
-
-    version = connection[:versions][rubygem_id: gem_id, number: dependency[:number], platform: dependency[:platform], indexed: true]
-
-    unless version
-      id = connection[:versions].insert(rubygem_id: gem_id, number: dependency[:number], platform: dependency[:platform])
-      version = { id: id, rubygem_id: gem_id, number: dependency[:number], platform: dependency[:platform], indexed: true }
-    end
-
-    dependency[:dependencies].each do |dep|
-      dep_name = dep.first
-      dep_requirements = dep.last
-      dep_gem = connection[:rubygems][name: dep_name]
-
-      if dep_gem
-        dep_gem_id = dep_gem[:id]
-      else
-        dep_gem_id = connection[:rubygems].insert(name: dep_name)
-      end
-
-      dependency_row = connection[:dependencies].where(rubygem_id: dep_gem_id, version_id: version[:id], scope: 'runtime').first
-
-      unless dependency_row
-        connection[:dependencies].insert(rubygem_id: dep_gem_id, version_id: version[:id], requirements: dep_requirements, scope: 'runtime')
-      end
-    end
-  end
-
   # @param [String] array of strings with the gem names
   def self.fetch_dependency(connection, gem)
     dataset = connection[<<-SQL, gem].all

--- a/lib/bundler_api/dep_calc.rb
+++ b/lib/bundler_api/dep_calc.rb
@@ -3,6 +3,50 @@ require 'bundler_api'
 class BundlerApi::DepCalc
   DepKey = Struct.new(:name, :number, :platform)
 
+  # TODO: These 2 methods may not really belong here
+  # TODO: There are a lot more queries than are probably needed
+  # TODO: Should this stuff be wrapped in a transaction?
+  def self.store_dependencies(connection, dependencies)
+    dependencies.each do |dep|
+      store_dependency(connection, dep)
+    end
+  end
+
+  def self.store_dependency(connection, dependency)
+    gem = connection[:rubygems][name: dependency[:name]]
+
+    if gem
+      gem_id = gem[:id]
+    else
+      gem_id = connection[:rubygems].insert(name: dependency[:name])
+    end
+
+    version = connection[:versions][rubygem_id: gem_id, number: dependency[:number], platform: dependency[:platform], indexed: true]
+
+    unless version
+      id = connection[:versions].insert(rubygem_id: gem_id, number: dependency[:number], platform: dependency[:platform])
+      version = { id: id, rubygem_id: gem_id, number: dependency[:number], platform: dependency[:platform], indexed: true }
+    end
+
+    dependency[:dependencies].each do |dep|
+      dep_name = dep.first
+      dep_requirements = dep.last
+      dep_gem = connection[:rubygems][name: dep_name]
+
+      if dep_gem
+        dep_gem_id = dep_gem[:id]
+      else
+        dep_gem_id = connection[:rubygems].insert(name: dep_name)
+      end
+
+      dependency_row = connection[:dependencies].where(rubygem_id: dep_gem_id, version_id: version[:id], scope: 'runtime').first
+
+      unless dependency_row
+        connection[:dependencies].insert(rubygem_id: dep_gem_id, version_id: version[:id], requirements: dep_requirements, scope: 'runtime')
+      end
+    end
+  end
+
   # @param [String] array of strings with the gem names
   def self.fetch_dependency(connection, gem)
     dataset = connection[<<-SQL, gem].all

--- a/lib/bundler_api/dep_fetcher.rb
+++ b/lib/bundler_api/dep_fetcher.rb
@@ -1,0 +1,167 @@
+require 'cgi'
+require 'open-uri'
+require 'set'
+require 'bundler_api'
+require 'bundler_api/dep_calc'
+require 'bundler_api/gem_helper'
+require 'bundler_api/metriks'
+require 'bundler_api/update/job'
+
+class BundlerApi::DepFetcher
+  def initialize(memcached_client)
+    @memcached_client = memcached_client
+    @fetchers = []
+  end
+
+  def <<(fetcher)
+    @fetchers << fetcher
+  end
+
+  def fetch(gems)
+    results = Results.new(@memcached_client, gems)
+
+    @fetchers.each do |fetcher|
+      break if results.done?
+      fetcher.fetch(results)
+    end
+
+    results.remaining_keys.each do |key|
+      @memcached_client.set(key, [])
+    end
+
+    results.dependencies
+  end
+
+  class Results
+    attr_reader :remaining_gems, :dependencies
+
+    def initialize(memcached_client, gems)
+      @memcached_client = memcached_client
+      @remaining_gems = Set.new(gems)
+      @dependencies = []
+    end
+
+    def done?
+      @remaining_gems.empty?
+    end
+
+    def remaining_keys
+      @remaining_gems.map { |g| "deps/v1/#{g}" }
+    end
+
+    def found(gem, result, cache = true)
+      @remaining_gems.delete gem
+      @dependencies += result
+
+      if cache
+        @memcached_client.set("deps/v1/#{gem}", result)
+      end
+    end
+
+    def found_key(key, result, cache = true)
+      found(key.sub('deps/v1/', ''), result, false)
+
+      if cache
+        @memcached_client.set(key, result)
+      end
+    end
+  end
+
+  class Memcached
+    def initialize(memcached_client)
+      @memcached_client = memcached_client
+    end
+
+    def fetch(results)
+      @memcached_client.get_multi(results.remaining_keys) do |key, value|
+        Metriks.meter('dependencies.memcached.hit').mark
+        results.found_key(key, value, false)
+      end
+    end
+  end
+
+  class Database
+    def initialize(connection)
+      @connection = connection
+    end
+
+    def fetch(results)
+      results.remaining_gems.each do |gem|
+        Metriks.meter('dependencies.memcached.miss').mark
+        result = BundlerApi::DepCalc.fetch_dependency(@connection, gem)
+
+        unless result.empty?
+          results.found(gem, result)
+        end
+      end
+    end
+  end
+
+  class GemServer
+    def initialize(cache, connection, rubygems_url)
+      @cache = cache
+      @connection = connection
+      @rubygems_url = rubygems_url
+    end
+
+    def fetch(results)
+      Metriks.meter('dependencies.database.miss').mark(results.remaining_gems.size)
+      dependencies = fetch_external(results.remaining_gems)
+      store(dependencies)
+
+      dependencies.group_by do |dep|
+        dep[:name]
+      end.each do |gem, dep|
+        results.found(gem, dep)
+      end
+    end
+
+    private
+
+    def fetch_external(gems)
+      puts "Fetching dependencies: #{gems.to_a.join(', ')}"
+      escaped_gems = gems.map { |gem| CGI.escape(gem) }
+      Marshal.load open("#{@rubygems_url}/api/v1/dependencies?gems=#{escaped_gems.join(',')}").read
+    end
+
+    # TODO: Should this do bulk inserts?
+    def store(dependencies)
+      payloads = get_payloads(dependencies)
+      names = Set.new
+
+      # TODO: I don't really like this transaction, but otherwise concurrent /api/v1/dependencies will be wrong
+      @connection.transaction do
+        payloads.each do |payload|
+          BundlerApi::Job.new(@connection, payload).run
+          names << payload.name
+        end
+      end
+
+      @cache.purge_specs
+      names.each { |name| @cache.purge_memory_cache(name) }
+    end
+
+    def get_payloads(dependencies)
+      dependencies.map do |dep|
+        version = Gem::Version.new(dep[:number])
+        payload = BundlerApi::GemHelper.new(dep[:name], version, dep[:platform], version.prerelease?)
+
+        spec = Gem::Specification.new do |s|
+          s.name = dep[:name]
+          s.version = dep[:number]
+          s.platform = dep[:platform]
+
+          dep[:dependencies].each do |d|
+            d.last.split(',').each do |requirement|
+              s.add_runtime_dependency(d.first, requirement.strip)
+            end
+          end
+        end
+
+        # TODO: Remove this temporary hack
+        payload.instance_variable_set(:@gemspec, spec)
+        payload
+      end
+    end
+  end
+end

--- a/lib/bundler_api/dep_fetcher.rb
+++ b/lib/bundler_api/dep_fetcher.rb
@@ -119,7 +119,9 @@ class BundlerApi::DepFetcher
     def fetch_external(gems)
       puts "Fetching dependencies: #{gems.to_a.join(', ')}"
       escaped_gems = gems.map { |gem| CGI.escape(gem) }
-      Marshal.load open("#{@rubygems_url}/api/v1/dependencies?gems=#{escaped_gems.join(',')}").read
+      open("#{@rubygems_url}/api/v1/dependencies?gems=#{escaped_gems.join(',')}") { |io|
+        Marshal.load(io.read)
+      }
     end
 
     # TODO: Should this do bulk inserts?


### PR DESCRIPTION
**Work In Progress**

This PR is primarily to solicit feedback.

The ultimate goal here (along with work from @pcarranza) is for a private bundler-api server which will locally cache gems and support private gems.

For this PR, the goal is to cache dependencies so that a private bundler-api server can get up and running with no need to pull all specs from rubygems.org... the dependencies will be pulled as needed to minimize the amount of traffic required from rubygems.org.