### PR TITLE
Add a caching strategy and a storage

### DIFF
--- a/lib/bundler_api/storage.rb
+++ b/lib/bundler_api/storage.rb
@@ -1,0 +1,60 @@
+require 'pathname'
+
+module BundlerApi
+  class GemStorage
+    def initialize(folder)
+      fail "Folder #{folder} does not exist or is not writable" unless File.writable?(folder)
+      @folder = Pathname.new(folder)
+    end
+
+    def get(name)
+      CachedGemFile.new(@folder, name)
+    end
+  end
+
+  class CachedGemFile
+    def initialize(folder, name)
+      @folder = folder.join(File.basename(name))
+      @name = name
+    end
+
+    def save(headers, content)
+      Dir.mkdir(@folder) unless Dir.exist?(@folder)
+      File.open(headers_path, 'w') {|f| f.write(headers.to_yaml) }
+      File.open(content_path, 'w') {|f| f.write(content) }
+      @headers = headers
+      @content = content
+    end
+
+    def exist?
+      content_path.exist? && headers_path.exist?
+    end
+
+    def content
+      load
+      @content
+    end
+
+    def headers
+      load
+      @headers
+    end
+
+    private
+
+    def load
+      return unless @content.nil? and @headers.nil?
+      fail "#{@name} does not exiat" unless exist?
+      @headers = File.open(headers_path) {|f| YAML.load(f.read) }
+      @content = File.open(content_path) {|f| f.read }
+    end
+
+    def content_path
+      @folder.join(@name)
+    end
+
+    def headers_path
+      @folder.join("headers.yaml")
+    end
+  end
+end

--- a/lib/bundler_api/strategy.rb
+++ b/lib/bundler_api/strategy.rb
@@ -11,7 +11,7 @@ module BundlerApi
     end
 
     def serve_gem(id, app)
-      app.redirect "#{RUBYGEMS_URL}/gems/#{:id}"
+      app.redirect "#{RUBYGEMS_URL}/gems/#{id}"
     end
 
     def serve_latest_specs(app)
@@ -30,7 +30,7 @@ module BundlerApi
   class CachingStrategy < RedirectionStrategy
     def initialize(storage, gem_fetcher: nil)
       @storage = storage
-      @gem_fetcher = GemFetcher.new || gem_fetcher
+      @gem_fetcher =  gem_fetcher ||GemFetcher.new
     end
 
     def serve_gem(id, app)

--- a/lib/bundler_api/strategy.rb
+++ b/lib/bundler_api/strategy.rb
@@ -1,32 +1,52 @@
 module BundlerApi
-  class RedirectionStrategy
-    def initialize(rubygems_url)
-      @rubygems_url = rubygems_url
-    end
+  RUBYGEMS_URL = (ENV['RUBYGEMS_URL'] || "https://www.rubygems.org").freeze
 
+  class RedirectionStrategy
     def serve_marshal(id, app)
-      app.redirect "#{@rubygems_url}/quick/Marshal.4.8/#{id}"
+      app.redirect "#{RUBYGEMS_URL}/quick/Marshal.4.8/#{id}"
     end
 
     def serve_actual_gem(id, app)
-      app.redirect "#{@rubygems_url}/fetch/actual/gem/#{:id}"
+      app.redirect "#{RUBYGEMS_URL}/fetch/actual/gem/#{id}"
     end
 
     def serve_gem(id, app)
-      app.redirect "#{@rubygems_url}/gems/#{:id}"
+      app.redirect "#{RUBYGEMS_URL}/gems/#{:id}"
     end
 
     def serve_latest_specs(app)
-      app.redirect "#{@rubygems_url}/latest_specs.4.8.gz"
+      app.redirect "#{RUBYGEMS_URL}/latest_specs.4.8.gz"
     end
 
     def serve_specs(app)
-      app.redirect "#{@rubygems_url}/specs.4.8.gz"
+      app.redirect "#{RUBYGEMS_URL}/specs.4.8.gz"
     end
 
     def serve_prerelease_specs(app)
-      app.redirect "#{@rubygems_url}/prerelease_specs.4.8.gz"
+      app.redirect "#{RUBYGEMS_URL}/prerelease_specs.4.8.gz"
+    end
+  end
+
+  class CachingStrategy < RedirectionStrategy
+    def initialize(storage, gem_fetcher: nil)
+      @storage = storage
+      @gem_fetcher = GemFetcher.new || gem_fetcher
     end
 
+    def serve_gem(id, app)
+      gem = @storage.get(id)
+      unless gem.exist?
+        headers, content = @gem_fetcher.fetch(id)
+        gem.save(headers, content)
+      end
+      app.headers.update(gem.headers)
+      gem.content
+    end
+  end
+
+  class GemFetcher
+    def fetch(id)
+      [{"CONTENT-TYPE" => "octet/stream"}, "zapatito"]
+    end
   end
 end

--- a/lib/bundler_api/web.rb
+++ b/lib/bundler_api/web.rb
@@ -16,7 +16,6 @@ require 'bundler_api/strategy'
 class BundlerApi::Web < Sinatra::Base
   API_REQUEST_LIMIT    = 200
   PG_STATEMENT_TIMEOUT = 1000
-  RUBYGEMS_URL         = ENV['RUBYGEMS_URL'] || "https://www.rubygems.org"
 
   unless ENV['RACK_ENV'] == 'test'
     use Appsignal::Rack::Listener, name: 'bundler-api'
@@ -42,8 +41,8 @@ class BundlerApi::Web < Sinatra::Base
 
     @cache = BundlerApi::CacheInvalidator.new
     @dalli_client = @cache.memcached_client
+    @gem_strategy = gem_strategy || BundlerApi::RedirectionStrategy.new
     super()
-    @gem_strategy = gem_strategy || BundlerApi::RedirectionStrategy.new(RUBYGEMS_URL)
   end
 
   set :root, File.join(File.dirname(__FILE__), '..', '..')

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'bundler_api/storage'
+
+describe BundlerApi::GemStorage do
+
+  it "Fails to build with an invalid path" do
+    invalid_folder = Dir.mktmpdir
+    FileUtils.remove_entry invalid_folder
+    expect { BundlerApi::GemStorage.new(invalid_folder) }
+      .to raise_error(/Folder #{invalid_folder} does not exist or is not writable/)
+  end
+
+  context "with a valid gem folder" do
+
+    before do
+      @gem_folder = Dir.mktmpdir
+    end
+
+    let(:storage) { BundlerApi::GemStorage.new(@gem_folder) }
+    let(:gem_name) { "my_gem-1.8.1.gem" }
+    let(:gem_headers) { Hash.new("CONTENT-TYPE" => "octet/stream") }
+    let(:gem_content) { "sentinel content" }
+
+    after do
+      FileUtils.remove_entry @gem_folder
+    end
+
+    it "returns a valid non-existing gem with a new gem" do
+      expect(storage.get(gem_name)).not_to exist
+    end
+
+    it "can retrieve a stored gem by name including headers and the content" do
+      storage.get(gem_name).save(gem_headers, gem_content)
+      cached_gem = storage.get(gem_name)
+      expect(cached_gem.content).to eq(gem_content)
+      expect(cached_gem.headers).to eq(gem_headers)
+    end
+
+    it "can replace the content of the gem" do
+      storage.get(gem_name).save(gem_headers, gem_content)
+      storage.get(gem_name).save(gem_headers, "new content")
+      cached_gem = storage.get(gem_name)
+      expect(cached_gem.content).to eq("new content")
+      expect(cached_gem.headers).to eq(gem_headers)
+    end
+  end
+
+end

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -1,0 +1,34 @@
+require 'rack/test'
+require 'spec_helper'
+require 'bundler_api/web'
+require 'bundler_api/strategy'
+require 'bundler_api/storage'
+
+describe BundlerApi::CachingStrategy do
+  include Rack::Test::Methods
+
+  before do
+    @gem_folder = Dir.mktmpdir
+  end
+
+  after do
+    FileUtils.remove_entry @gem_folder
+  end
+
+  let(:storage) { BundlerApi::GemStorage.new(@gem_folder) }
+
+  let(:app) {
+    BundlerApi::Web.new(
+      conn         = $db,
+      write_con    = $db,
+      gem_strategy = BundlerApi::CachingStrategy.new(storage))
+  }
+
+  it "fetchs the gem file, stores, and serves it" do
+    get "/gems/rack"
+    expect(last_response.body).to eq('zapatito')
+    expect(last_response.header["CONTENT-TYPE"]).to eq('octet/stream')
+    expect(storage.get("rack")).to exist
+  end
+
+end


### PR DESCRIPTION
RFC

For now this is quite simple, given a folder, we can create a storage which is capable of getting a CachedGem instance.

This can either exist or not, and can be used to save both headers and the content of the file.

The storage is tested, the caching strategy has only 1 test that checks that given a gem name, it will fetch the gem, store it, and return this cached data.

Next steps will be to test further and to actually call rubygems to fetch the gem and the headers from there.

Not suitable for merging yet