### PR TITLE
Lazy load dependencies from rubygems.org

### DIFF
--- a/lib/bundler_api/dependency_strategy.rb
+++ b/lib/bundler_api/dependency_strategy.rb
@@ -1,0 +1,68 @@
+require 'set'
+require 'bundler_api/dep_calc'
+require 'bundler_api/metriks'
+require 'bundler_api/web_helper'
+
+module BundlerApi::DependencyStrategy
+  class Database
+    def initialize(memcached_client, connection)
+      @memcached_client = memcached_client
+      @conn = connection
+    end
+
+    def fetch(gems)
+      dependencies = []
+      keys = gems.map { |g| "deps/v1/#{g}" }
+      @memcached_client.get_multi(keys) do |key, value|
+        Metriks.meter('dependencies.memcached.hit').mark
+        keys.delete(key)
+        dependencies += value
+      end
+
+      keys.each do |gem|
+        Metriks.meter('dependencies.memcached.miss').mark
+        name = gem.gsub('deps/v1/', '')
+        result = BundlerApi::DepCalc.fetch_dependency(@conn, name)
+        @memcached_client.set(gem, result)
+        dependencies += result
+      end
+      dependencies
+    end
+  end
+
+  class GemServer
+    RUBYGEMS_URL = (ENV['RUBYGEMS_URL'] || "https://www.rubygems.org").freeze
+    EXPIRY = 30 * 60
+
+    def initialize(memcached_client, web_helper = nil)
+      @memcached_client = memcached_client
+      @web_helper = web_helper || BundlerApi::WebHelper.new
+    end
+
+    def fetch(gems)
+      dependencies = []
+      keys = gems.map { |g| "deps/v1/#{g}" }
+      @memcached_client.get_multi(keys) do |key, value|
+        Metriks.meter('dependencies.memcached.hit').mark
+        keys.delete(key)
+        dependencies += value
+      end
+
+      unless keys.empty?
+        Metriks.meter('dependencies.memcached.miss').mark(keys.size)
+        gems = keys.map { |g| g.gsub('deps/v1/', '') }
+        escaped_gems = gems.map { |gem| CGI.escape(gem) }
+        puts "Fetching dependencies: #{gems.join(', ')}"
+        results = Marshal.load @web_helper.get("#{RUBYGEMS_URL}/api/v1/dependencies?gems=#{escaped_gems.join(',')}")
+        results.group_by { |result|
+          result[:name]
+        }.each do |gem, result|
+          @memcached_client.set("deps/v1/#{gem}", result, EXPIRY)
+          dependencies += result
+        end
+      end
+
+      dependencies
+    end
+  end
+end

--- a/lib/bundler_api/strategy.rb
+++ b/lib/bundler_api/strategy.rb
@@ -1,3 +1,5 @@
+require 'bundler_api/dependency_strategy'
+
 module BundlerApi
   class RedirectionStrategy
     def initialize(rubygems_url)

--- a/lib/bundler_api/web.rb
+++ b/lib/bundler_api/web.rb
@@ -5,7 +5,6 @@ require 'bundler_api'
 require 'bundler_api/agent_reporting'
 require 'bundler_api/appsignal'
 require 'bundler_api/cache'
-require 'bundler_api/dep_calc'
 require 'bundler_api/metriks'
 require 'bundler_api/runtime_instrumentation'
 require 'bundler_api/gem_helper'
@@ -41,9 +40,9 @@ class BundlerApi::Web < Sinatra::Base
     end
 
     @cache = BundlerApi::CacheInvalidator.new
-    @dalli_client = @cache.memcached_client
     super()
     @gem_strategy = gem_strategy || BundlerApi::RedirectionStrategy.new(RUBYGEMS_URL)
+    @dep_strategy = BundlerApi::DependencyStrategy::Database.new(@cache.memcached_client, @conn)
   end
 
   set :root, File.join(File.dirname(__FILE__), '..', '..')
@@ -94,7 +93,7 @@ class BundlerApi::Web < Sinatra::Base
 
     content_type 'application/octet-stream'
 
-    deps = with_metriks { get_cached_dependencies }
+    deps = with_metriks { @dep_strategy.fetch(gems) }
     ActiveSupport::Notifications.instrument('marshal.deps') { Marshal.dump(deps) }
   end
 
@@ -106,7 +105,7 @@ class BundlerApi::Web < Sinatra::Base
 
     content_type 'application/json;charset=UTF-8'
 
-    deps = with_metriks { get_cached_dependencies }
+    deps = with_metriks { @dep_strategy.fetch(gems) }
     ActiveSupport::Notifications.instrument('json.deps') { deps.to_json }
   end
 
@@ -174,24 +173,5 @@ class BundlerApi::Web < Sinatra::Base
     end
   ensure
     timer.stop if timer
-  end
-
-  def get_cached_dependencies
-    dependencies = []
-    keys = gems.map { |g| "deps/v1/#{g}" }
-    @dalli_client.get_multi(keys) do |key, value|
-      Metriks.meter('dependencies.memcached.hit').mark
-      keys.delete(key)
-      dependencies += value
-    end
-
-    keys.each do |gem|
-      Metriks.meter('dependencies.memcached.miss').mark
-      name = gem.gsub("deps/v1/", "")
-      result = BundlerApi::DepCalc.fetch_dependency(@conn, name)
-      @dalli_client.set(gem, result)
-      dependencies += result
-    end
-    dependencies
   end
 end

--- a/lib/bundler_api/web_helper.rb
+++ b/lib/bundler_api/web_helper.rb
@@ -1,0 +1,8 @@
+require 'bundler_api'
+require 'open-uri'
+
+class BundlerApi::WebHelper
+  def get(url)
+    open(url) { |io| io.read }
+  end
+end

--- a/spec/dependency_strategy_spec.rb
+++ b/spec/dependency_strategy_spec.rb
@@ -1,0 +1,147 @@
+require 'spec_helper'
+require 'bundler_api/web'
+require 'bundler_api/dependency_strategy'
+require 'support/gem_builder'
+
+describe BundlerApi::DependencyStrategy::Database do
+  let(:memcached_client) { BundlerApi::CacheInvalidator.new.memcached_client }
+  let(:strategy) { BundlerApi::DependencyStrategy::Database.new(memcached_client, $db) }
+
+  before do
+    builder = GemBuilder.new($db)
+
+    %w(foo bar).each do |gem|
+      id = builder.create_rubygem(gem)
+      builder.create_version(id, gem)
+    end
+  end
+
+  describe ".fetch" do
+    context "one gem" do
+      it "finds the gem" do
+        result = [{
+          name:         "foo",
+          number:       "1.0.0",
+          platform:     "ruby",
+          dependencies: []
+        }]
+
+        expect(strategy.fetch(%w(foo))).to eq(result)
+      end
+    end
+
+    context "multiple gems" do
+      it "finds the gems" do
+        result = [{
+          name:         "foo",
+          number:       "1.0.0",
+          platform:     "ruby",
+          dependencies: []
+        }, {
+          name:         "bar",
+          number:       "1.0.0",
+          platform:     "ruby",
+          dependencies: []
+        }]
+
+        expect(strategy.fetch(%w(foo bar))).to eq(result)
+      end
+    end
+
+    context "some missing gems" do
+      it "finds the available gems" do
+        result = [{
+          name:         "foo",
+          number:       "1.0.0",
+          platform:     "ruby",
+          dependencies: []
+        }, {
+          name:         "bar",
+          number:       "1.0.0",
+          platform:     "ruby",
+          dependencies: []
+        }]
+
+        expect(strategy.fetch(%w(foo bar baz))).to eq(result)
+      end
+    end
+  end
+end
+
+describe BundlerApi::DependencyStrategy::GemServer do
+  let(:memcached_client) { BundlerApi::CacheInvalidator.new.memcached_client }
+  let(:web_helper) { double }
+  let(:strategy) { BundlerApi::DependencyStrategy::GemServer.new(memcached_client, web_helper) }
+
+  def valid_url(url, expected_gems)
+    expect(url).to start_with('https://www.rubygems.org/api/v1/dependencies?gems=')
+    params = url.sub('https://www.rubygems.org/api/v1/dependencies?gems=', '')
+    expect(params.split(',')).to match_array(expected_gems)
+  end
+
+  describe ".fetch" do
+    context "one gem" do
+      it "finds the gem" do
+        result = [{
+          name:         'foo',
+          number:       '1.0.0',
+          platform:     'ruby',
+          dependencies: []
+        }]
+
+        expect(web_helper).to receive(:get) { |url|
+          valid_url(url, %w(foo))
+          Marshal.dump(result)
+        }
+
+        expect(strategy.fetch(%w(foo))).to eq(result)
+      end
+    end
+
+    context "multiple gems" do
+      it "finds the gems" do
+        result = [{
+          name:         'foo',
+          number:       '1.0.0',
+          platform:     'ruby',
+          dependencies: []
+        }, {
+          name:         'bar',
+          number:       '1.0.0',
+          platform:     'ruby',
+          dependencies: []
+        }]
+
+        expect(web_helper).to receive(:get) { |url|
+          valid_url(url, %w(foo bar))
+          Marshal.dump(result)
+        }
+
+        expect(strategy.fetch(%w(foo bar))).to eq(result)
+      end
+    end
+
+    context "some missing gems" do
+      it "finds the available gems" do
+        result = [{
+          name:         'foo',
+          number:       '1.0.0',
+          platform:     'ruby',
+          dependencies: []
+        }, {
+          name:         'bar',
+          number:       '1.0.0',
+          platform:     'ruby',
+          dependencies: []
+        }]
+
+        expect(web_helper).to receive(:get) { |url|
+          valid_url(url, %w(foo bar baz))
+          Marshal.dump(result)
+        }
+
+        expect(strategy.fetch(%w(foo bar baz))).to eq(result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Work In Progress**

This PR is primarily to solicit feedback.

The ultimate goal here (along with work from @pcarranza) is for a private bundler-api server which will locally cache gems and support private gems.

For this PR, the goal is to cache dependencies so that a private bundler-api server can get up and running with no need to pull all specs from rubygems.org... the dependencies will be pulled as needed to minimize the amount of traffic required from rubygems.org. Dependencies will then be stored directly to memcached with a 30 minute timeout, to avoid frequent hitting of rubygems.org for the same dependencies.