### PR TITLE
update download url to use fastly

### DIFF
--- a/.env
+++ b/.env
@@ -12,4 +12,4 @@ REDIS_ENV=REDIS_URL
 REDIS_URL=redis://127.0.0.1:6379
 MEMCACHE_SERVERS=127.0.0.1:11211
 RUBYGEMS_HOST=http://rubygems.org
-DOWNLOAD_BASE=http://production.s3.rubygems.org
+DOWNLOAD_BASE=https://rubygems.global.ssl.fastly.net

--- a/.env
+++ b/.env
@@ -11,5 +11,5 @@ MAX_THREADS=16
 REDIS_ENV=REDIS_URL
 REDIS_URL=redis://127.0.0.1:6379
 MEMCACHE_SERVERS=127.0.0.1:11211
-RUBYGEMS_HOST=http://rubygems.org
+RUBYGEMS_URL=https://rubygems.org
 DOWNLOAD_BASE=https://rubygems.global.ssl.fastly.net

--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,7 @@ def download_index(url)
 end
 
 def get_specs
-  rubygems_host          = ENV.fetch("RUBYGEMS_HOST", "http://rubygems.org")
+  rubygems_host          = ENV.fetch("RUBYGEMS_URL", "https://rubygems.org")
   specs_uri              = File.join(rubygems_host, "specs.4.8.gz")
   prerelease_specs_uri   = File.join(rubygems_host, "prerelease_specs.4.8.gz")
   specs_threads          = []

--- a/lib/bundler_api/gem_helper.rb
+++ b/lib/bundler_api/gem_helper.rb
@@ -30,7 +30,7 @@ class BundlerApi::GemHelper < Struct.new(:name, :version, :platform, :prerelease
   end
 
   def download_spec(base = nil)
-    base ||= ENV.fetch("DOWNLOAD_BASE", "http://production.s3.rubygems.org")
+    base ||= ENV.fetch("DOWNLOAD_BASE", "https://rubygems.global.ssl.fastly.net")
     url = "#{base}/quick/Marshal.4.8/#{full_name}.gemspec.rz"
     set_checksum
     @mutex.synchronize do


### PR DESCRIPTION
(instead of old hardcoded s3 bucket)
This is already running in production via heroku config variable.

@indirect @andremedeiros @evanphx 