### PR TITLE
use dalli stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'puma'
 gem 'puma_worker_killer'
 gem 'rack-timeout', '0.4.0.beta.1', github: 'indirect/rack-timeout'
 gem 'rake'
-gem 'dalli', github: 'indirect/dalli'
+gem 'dalli'
 gem 'redis'
 gem 'sequel'
 gem 'sequel_pg', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,4 @@
 GIT
-  remote: https://github.com/indirect/dalli.git
-  revision: 4be6be64e643eaaef76310ad6e67ffef8ce32980
-  specs:
-    dalli (2.7.4)
-
-GIT
   remote: https://github.com/indirect/metriks-librato_metrics.git
   revision: 15bcaf51dad18b4e7d6f29fb7f7adc7eaf215c5d
   specs:
@@ -33,6 +27,7 @@ GEM
     byebug (8.2.1)
     coderay (1.1.0)
     compact_index (0.10.0)
+    dalli (2.7.6)
     diff-lcs (1.2.5)
     dotenv (2.0.2)
     faraday (0.9.2)
@@ -117,7 +112,7 @@ DEPENDENCIES
   appsignal (= 0.11.6.beta.0)
   artifice
   compact_index
-  dalli!
+  dalli
   dotenv
   foreman
   json


### PR DESCRIPTION
I am suspecting that https://github.com/indirect/dalli/commit/4be6be64e643eaaef76310ad6e67ffef8ce32980 could be causing slow multi_gets in memcached