### PR TITLE
Use memcached instead of Dalli

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'puma'
 gem 'puma_worker_killer'
 gem 'rack-timeout', '0.4.0.beta.1', github: 'indirect/rack-timeout'
 gem 'rake'
-gem 'dalli'
+gem 'memcached', github: 'arthurnn/memcached'
 gem 'redis'
 gem 'sequel'
 gem 'sequel_pg', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: https://github.com/arthurnn/memcached.git
+  revision: 3a5ba7fc46510b0bf1528ac2a145ecc740f02709
+  specs:
+    memcached (2.0.0.alpha)
+
+GIT
   remote: https://github.com/indirect/metriks-librato_metrics.git
   revision: 15bcaf51dad18b4e7d6f29fb7f7adc7eaf215c5d
   specs:
@@ -27,7 +33,6 @@ GEM
     byebug (8.2.1)
     coderay (1.1.0)
     compact_index (0.10.0)
-    dalli (2.7.6)
     diff-lcs (1.2.5)
     dotenv (2.0.2)
     faraday (0.9.2)
@@ -112,12 +117,12 @@ DEPENDENCIES
   appsignal (= 0.11.6.beta.0)
   artifice
   compact_index
-  dalli
   dotenv
   foreman
   json
   librato-metrics
   lock-smith
+  memcached!
   metriks-librato_metrics!
   metriks-middleware
   newrelic_rpm
@@ -136,9 +141,6 @@ DEPENDENCIES
   sequel
   sequel_pg
   sinatra
-
-RUBY VERSION
-   ruby 2.3.0p0
 
 BUNDLED WITH
    1.12.0.rc

--- a/lib/bundler_api/cache.rb
+++ b/lib/bundler_api/cache.rb
@@ -1,5 +1,5 @@
 require 'net/http'
-require 'dalli'
+require 'memcached'
 
 module BundlerApi
   FastlyClient = Struct.new(:service_id, :base_url, :api_key) do
@@ -68,17 +68,14 @@ module BundlerApi
     def memcached_client
       @memcached_client ||= if ENV["MEMCACHEDCLOUD_SERVERS"]
         servers = (ENV["MEMCACHEDCLOUD_SERVERS"] || "").split(",")
-        Dalli::Client.new(
+        Memcached::Client.new(
           servers, {
-            username: ENV["MEMCACHEDCLOUD_USERNAME"],
-            password: ENV["MEMCACHEDCLOUD_PASSWORD"],
-            failover: true,
-            socket_timeout: 1.5,
-            socket_failure_delay: 0.2
+            prefix_key: 'v2',
+            credentials: [ENV["MEMCACHEDCLOUD_USERNAME"], ENV["MEMCACHEDCLOUD_PASSWORD"]]
           }
         )
       else
-        Dalli::Client.new
+        Memcached::Client.new
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 ENV['RACK_ENV'] = 'test'
 require 'bundler_api/env'
 
-require 'dalli'
+require 'memcached'
 require 'rspec/core'
 require 'rspec/mocks'
 
@@ -30,7 +30,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    Dalli::Client.new.flush
+    Memcached::Client.new.flush
   end
 
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
I mentioned the other day that the [memcached](https://github.com/arthurnn/memcached) gem is faster than Dalli, specially on multi_get, this is the latest 2.0 benchmarks on multi_get, compared with dalli.

```
get-multi: dalli:bin                   8.400000   3.700000  12.100000 ( 12.739551)
get-multi: libm:ascii                  0.990000   1.260000   2.250000 (  3.418817)
get-multi: libm:ascii:pipeline         1.000000   1.270000   2.270000 (  3.425416)
get-multi: libm:ascii:udp              0.900000   0.720000   1.620000 (  1.910331)
get-multi: libm:bin                    1.160000   2.580000   3.740000 (  5.758965)
get-multi: libm:bin:buffer             1.190000   2.660000   3.850000 (  5.901414)
```

WARNING:  this memcached version is not been used in production yet. However all tests here are passing, and also the gem itself has a lot of tests.

@indirect @dwradcliffe what do you think about us merging this, giving a try and revert if we see anything strange ?