### PR TITLE
Purge gem before purging specs

### DIFF
--- a/lib/bundler_api/web.rb
+++ b/lib/bundler_api/web.rb
@@ -124,8 +124,8 @@ class BundlerApi::Web < Sinatra::Base
       job.run
 
       in_background do
-        @cache.purge_specs
         @cache.purge_gem(payload.name)
+        @cache.purge_specs
       end
 
       json_payload(payload)
@@ -143,8 +143,8 @@ class BundlerApi::Web < Sinatra::Base
       ).update(indexed: false)
 
       in_background do
-        @cache.purge_specs
         @cache.purge_gem(payload.name)
+        @cache.purge_specs
       end
 
       json_payload(payload)

--- a/lib/bundler_api/web.rb
+++ b/lib/bundler_api/web.rb
@@ -276,7 +276,7 @@ private
       begin
         yield
       rescue => e
-        Appsignal.add_exception(e)
+        Appsignal.send_exception(e)
       end
     end
   end


### PR DESCRIPTION
Fixes the issues caused by https://github.com/bundler/bundler-api/pull/156 :(

This way, if purging fastly fails for purging the specs, at least
memcached will be purged for the dependency API. Finishes up https://github.com/bundler/bundler-api/pull/160.

Add exception only will add the exception to the current appsignal
transaction. If there is no transaction, I think that means we never get
the exception. Sending it actually sends it.
