### PR TITLE
Purge a gem with its gem_helper 

### DIFF
--- a/lib/bundler_api/cache.rb
+++ b/lib/bundler_api/cache.rb
@@ -54,12 +54,15 @@ module BundlerApi
       verify_responses!(responses)
     end
 
-    def purge_gem(name)
+    def purge_gem(gem_helper)
+      name = gem_helper.name
+      full_name = gem_helper.full_name
+
       purge_memory_cache(name)
 
       paths = %W(
-        /quick/Marshal.4.8/#{name}.gemspec.rz
-        /gems/#{name}.gem
+        /quick/Marshal.4.8/#{full_name}.gemspec.rz
+        /gems/#{full_name}.gem
         /info/#{name}
       )
       puts "Purging #{paths.join(', ')}"

--- a/lib/bundler_api/cache.rb
+++ b/lib/bundler_api/cache.rb
@@ -34,7 +34,7 @@ module BundlerApi
       failures = responses.compact.select {|r| r.code.to_i >= 400 }
       return if failures.empty?
       failures.map! do |response|
-        "- #{response.uri} => #{response.code}, #{response.body if response.body_permitted?}"
+        "- #{response.uri} => #{response.code}, #{response.body}"
       end
       raise "The following cache purge requests failed:\n#{failures.join("\n")}"
     end

--- a/lib/bundler_api/web.rb
+++ b/lib/bundler_api/web.rb
@@ -124,7 +124,7 @@ class BundlerApi::Web < Sinatra::Base
       job.run
 
       in_background do
-        @cache.purge_gem(payload.name)
+        @cache.purge_gem(payload)
         @cache.purge_specs
       end
 
@@ -143,7 +143,7 @@ class BundlerApi::Web < Sinatra::Base
       ).update(indexed: false)
 
       in_background do
-        @cache.purge_gem(payload.name)
+        @cache.purge_gem(payload)
         @cache.purge_specs
       end
 

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -4,28 +4,48 @@ require 'bundler_api/cache'
 describe BundlerApi::CacheInvalidator do
   let(:client) { double(:client, purge_path: nil, purge_key: nil) }
   let(:cache) { BundlerApi::CacheInvalidator.new(cdn: client) }
+  let(:failing_response) { double('Net::HTTPServerError', :uri => 'URI', :code => 500, :body => 'fail!') }
+  let(:response) { double('Net::HTTPOK', :code => 200, :body => '') }
 
   describe '.purge_specs' do
     subject { cache.purge_specs }
 
     it 'purges dependencies key' do
-      expect(client).to receive(:purge_key).with('dependencies')
+      expect(client).to receive(:purge_key).with('dependencies').and_return(response)
       subject
     end
 
     it 'purges latest specs' do
-      expect(client).to receive(:purge_path).with('/latest_specs.4.8.gz')
+      expect(client).to receive(:purge_path).with('/latest_specs.4.8.gz').and_return(response)
       subject
     end
 
     it 'purges specs' do
-      expect(client).to receive(:purge_path).with('/specs.4.8.gz')
+      expect(client).to receive(:purge_path).with('/specs.4.8.gz').and_return(response)
       subject
     end
 
     it 'purges prerelease specs' do
-      expect(client).to receive(:purge_path).with('/prerelease_specs.4.8.gz')
+      expect(client).to receive(:purge_path).with('/prerelease_specs.4.8.gz').and_return(response)
       subject
+    end
+
+    it 'purges names' do
+      expect(client).to receive(:purge_path).with('/names').and_return(response)
+      subject
+    end
+
+    it 'purges versions' do
+      expect(client).to receive(:purge_path).with('/versions').and_return(response)
+      subject
+    end
+
+    it 'raises when a purge returns a failing HTTP response' do
+      expect(client).to receive(:purge_path).with('/versions').and_return(failing_response)
+      expect { subject }.to raise_error <<-E.strip
+The following cache purge requests failed:
+- URI => 500, fail!
+      E
     end
 
     context 'with a nil client' do
@@ -38,19 +58,39 @@ describe BundlerApi::CacheInvalidator do
   end
 
   describe '.purge_gem' do
-    let(:name) { 'bundler-1.0.0' }
-    subject { cache.purge_gem(name) }
+    let(:name) { 'bundler' }
+    let(:gem_helper) { BundlerApi::GemHelper.new(name, '1.0.0', 'ruby', false) }
+    subject { cache.purge_gem(gem_helper) }
 
     it 'purges gemspec' do
       expect(client).to receive(:purge_path)
         .with('/quick/Marshal.4.8/bundler-1.0.0.gemspec.rz')
+        .and_return(response)
       subject
     end
 
     it 'purges gem' do
       expect(client).to receive(:purge_path)
         .with('/gems/bundler-1.0.0.gem')
+        .and_return(response)
       subject
+    end
+
+    it 'purges new index info' do
+      expect(client).to receive(:purge_path)
+        .with('/info/bundler')
+        .and_return(response)
+      subject
+    end
+
+    it 'raises when a purge returns a failing HTTP response' do
+      expect(client).to receive(:purge_path)
+        .with('/info/bundler')
+        .and_return(failing_response)
+      expect { subject }.to raise_error <<-E.strip
+The following cache purge requests failed:
+- URI => 500, fail!
+      E
     end
 
     it "purges memcached gem" do


### PR DESCRIPTION
This ensures we can use the full_name to purge the .gem and the .gemspec and only the name for memcache and the info endpoint

\c @indirect @dwradcliffe 