### PR TITLE
Add rake task to purge compact index from Fastly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -226,7 +226,7 @@ end
 desc "Purge new index from Fastly cache"
 task :purge_cdn do
   cdn = BundlerApi::CacheInvalidator.new.cdn_client
-  cdn.purge_key("names")
-  cdn.purge_key("versions")
+  cdn.purge_path("/names")
+  cdn.purge_path("/versions")
   cdn.purge_key("info/*")
 end

--- a/Rakefile
+++ b/Rakefile
@@ -222,3 +222,11 @@ task :yank_spec, :name, :version, :platform do |t, args|
   end
   puts "Yanked #{version}!"
 end
+
+desc "Purge new index from Fastly cache"
+task :purge_cdn do
+  cdn = BundlerApi::CacheInvalidator.new.cdn_client
+  cdn.purge_key("names")
+  cdn.purge_key("versions")
+  cdn.purge_key("info/*")
+end


### PR DESCRIPTION
I already did the Fastly configuration to make the wildcard purge work, but the wildcard requires that we do one last purge all before the surrogate keys will be tagged correctly so we can purge them together.

/cc @segiddins @dwradcliffe