### PR TITLE
Drop Fastly cache time to 1 hour

### DIFF
--- a/lib/bundler_api/web.rb
+++ b/lib/bundler_api/web.rb
@@ -208,7 +208,7 @@ private
     sum.checksum = Digest::MD5.hexdigest(response_body)
 
     headers "ETag" => quote(sum.checksum)
-    headers "Surrogate-Control" => "max-age=2592000, stale-while-revalidate=60"
+    headers "Surrogate-Control" => "max-age=3600, stale-while-revalidate=60"
     content_type "text/plain"
     requested_range_for(response_body)
   end


### PR DESCRIPTION
By doing this, we can at least be sure that gem pushes will show up in the compact index within 60 minutes, even if we somehow miss the webhook from rubygems.org or the Fastly purge request fails to send. (For example, this would have fixed bundler/bundler#4495 without any human intervention.)