### PR TITLE
Purge gem cache directly in BundlerApi::Job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -204,11 +204,10 @@ end
 desc "Add a specific single gem version to the database"
 task :add_spec, :name, :version, :platform, :prerelease do |t, args|
   cache = BundlerApi::CacheInvalidator.new
-  mutex = Mutex.new
   args.with_defaults(:platform => 'ruby', :prerelease => false)
   payload = BundlerApi::GemHelper.new(args[:name], Gem::Version.new(args[:version]), args[:platform], args[:prerelease])
   database_connection do |db|
-    BundlerApi::Job.new(db, payload, mutexm, 0, cache: cache).run
+    BundlerApi::Job.new(db, payload, cache: cache).run
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -95,6 +95,7 @@ def update(db, thread_count)
   local_gems    = get_local_gems(db)
   prerelease    = false
   pool          = BundlerApi::ConsumerPool.new(thread_count)
+  cache         = BundlerApi::CacheInvalidator.new
 
   if (specs.size - 1) == local_gems.size
     puts "Gem counts match, seems like we're already up to date!"
@@ -111,7 +112,7 @@ def update(db, thread_count)
     name, version, platform = spec
     payload = BundlerApi::GemHelper.new(name, version, platform, prerelease)
     pool.enq(BundlerApi::YankJob.new(local_gems, payload, yank_mutex))
-    pool.enq(BundlerApi::Job.new(db, payload, mutex, add_gem_count))
+    pool.enq(BundlerApi::Job.new(db, payload, mutex, add_gem_count, cache: cache))
   end
 
   print "Finished Enqueuing Jobs!\n"
@@ -202,10 +203,12 @@ end
 
 desc "Add a specific single gem version to the database"
 task :add_spec, :name, :version, :platform, :prerelease do |t, args|
+  cache = BundlerApi::CacheInvalidator.new
+  mutex = Mutex.new
   args.with_defaults(:platform => 'ruby', :prerelease => false)
   payload = BundlerApi::GemHelper.new(args[:name], Gem::Version.new(args[:version]), args[:platform], args[:prerelease])
   database_connection do |db|
-    BundlerApi::Job.new(db, payload).run
+    BundlerApi::Job.new(db, payload, mutexm, 0, cache: cache).run
   end
 end
 

--- a/lib/bundler_api/update/job.rb
+++ b/lib/bundler_api/update/job.rb
@@ -12,7 +12,7 @@ class BundlerApi::Job
   attr_reader :payload
   @@gem_cache = {}
 
-  def initialize(db, payload, mutex = Mutex.new, gem_count = nil, fix_deps: false, silent: false)
+  def initialize(db, payload, mutex = Mutex.new, gem_count = nil, fix_deps: false, silent: false, cache: nil)
     @db        = db
     @payload   = payload
     @mutex     = mutex || MockMutex.new
@@ -21,6 +21,7 @@ class BundlerApi::Job
     @gem_info  = BundlerApi::GemInfo.new(@db)
     @fix_deps  = fix_deps
     @silent    = silent
+    @cache     = cache
   end
 
   def run
@@ -32,6 +33,7 @@ class BundlerApi::Job
     @mutex.synchronize do
       deps_added = insert_spec(spec, checksum)
       @gem_count.increment if @gem_count && (!deps_added.empty? || !@fix_deps)
+      @cache.purge_gem(@payload) if @cache
     end
   rescue BundlerApi::HTTPError => e
     log "BundlerApi::Job#run gem=#{@payload.full_name.inspect} " +


### PR DESCRIPTION
Run example:

```
# of non yanked local gem versions: 720350
Finished Enqueuing Jobs!
Adding: repres-bootstrap-1.0.3
Purging /quick/Marshal.4.8/repres-bootstrap-1.0.3.gemspec.rz, /gems/repres-bootstrap-1.0.3.gem, /info/repres-bootstrap
Adding: repres-react-1.0.4
Purging /quick/Marshal.4.8/repres-react-1.0.4.gemspec.rz, /gems/repres-react-1.0.4.gem, /info/repres-react
```