### PR TITLE
Fix rake yank_spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -236,8 +236,8 @@ task :yank_spec, :name, :version, :platform do |t, args|
     ).first
     version.update(indexed: false, yanked_at: Time.now)
 
+    puts "Yanked #{version}!"
   end
-  puts "Yanked #{version}!"
 end
 
 desc "Purge new index from Fastly cache"


### PR DESCRIPTION
```
{:name=>"jekyll-multiple-lang", :version=>"1.0.1"}
Connecting to database with up to 1 connections... connected!
rake aborted!
NameError: undefined local variable or method `version' for main:Object
/home/ubuntu/www/bundler-api/Rakefile:241:in `block in <top (required)>'
/home/ubuntu/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `eval'
/home/ubuntu/.rvm/gems/ruby-2.3.1/bin/ruby_executable_hooks:15:in `<main>'
```